### PR TITLE
Fix routing direction in Speech History mode

### DIFF
--- a/addon/globalPlugins/brailleExtender/speechhistorymode.py
+++ b/addon/globalPlugins/brailleExtender/speechhistorymode.py
@@ -186,7 +186,7 @@ def showSpeechFromRoutingIndex(routingNumber):
 	elif routingNumber == braille.handler.displaySize - 1:
 		ui.browseableMessage(speechList[index])
 	else:
-		direction = routingNumber > braille.handler.displaySize / 2
+		direction = routingNumber + 1 > braille.handler.displaySize / 2
 		if direction:
 			index = index - (braille.handler.displaySize - routingNumber) + 1
 		else:


### PR DESCRIPTION

Previously, if the display had 40 cells, the maximum one could go right in the history was 20. The maximum one could go left was 18.